### PR TITLE
fixed run_std_dev

### DIFF
--- a/matlab/Micromet/run_std_dev.m
+++ b/matlab/Micromet/run_std_dev.m
@@ -8,6 +8,12 @@ function data=run_std_dev(data,clean_tv,wlen,thres,verbose)
 %       of std and mean.
 % thres: threshold for rejecting outlier. 
 
+% Revision: 
+% 
+% May 2, 2023 (June)
+%     nanstd and nanmean are depreciated
+%     switched to std(__,'omitnan')
+
 arg_default('verbose',0); % by default don't print anything
 TF='yyyy/mm/dd HH:MM'; % time format
 s = inputname(1);      % to identify which variable you are processing
@@ -29,13 +35,13 @@ target_p=pm(:,wlen/2+1);
 g(:,wlen/2+1)=[];
 pm(:,wlen/2+1)=[];
 
-gstd=nanstd(g,[],2);   % group standard deviation
-gavg=nanmean(g,2);     % group average
+% nanstd and nanmean are depreciated - don't work in 2022b 
+% https://www.mathworks.com/help/stats/nanmean.html
+gstd=std(g,[],2,"omitnan");
+gavg=mean(g,2,"omitnan");
 g_low=gavg-thres*gstd; % lower bound of the group
 g_up=gavg+thres*gstd;  % upper bound of the group
-
 rj=target_p(target<g_low| target>g_up); % find positions of data outside the range in the original array
-
 if ~isempty(rj) && verbose~=0
     data(rj)=NaN;
     fprintf(1,'- %s: [run_std_dev] total=%d\n',s,length(rj));


### PR DESCRIPTION
Minor change - submitting as a pull request, leaving to decision to merge to @znesic 

I updated to matlab 2022b (because it has some enhanced functionality for calling matlab from python).  After the update, nanmean and nanstd were failing in this function were failing.  The docs suggest they are not compatible in 2022b: https://www.mathworks.com/help/stats/nanmean.html#mw_2f75601e-c5eb-4725-a1f6-52c1a8a0446a

Updated to use mean/std with the 'omitnan' tag instead.  Might be good to use this convention henceforth? 

