### PR TITLE
Adding tags for FirstStage.ini files. Adding DerivedVariables/siteID_CustomTags.m option.

### DIFF
--- a/matlab/BIOMET/fr_automated_cleaning.m
+++ b/matlab/BIOMET/fr_automated_cleaning.m
@@ -39,10 +39,15 @@ function fr_automated_cleaning(Years,Sites,stages,db_out,db_ini)
 %    to use a local copy of the database.
 
 
-% kai* Feb 12, 2003                     Last modified: Feb 12, 2024
+% kai* Feb 12, 2003                     Last modified: Mar 22, 2024
 %
 % Revisions:
 % 
+% Mar 22, 2024 (Zoran)
+%   - renamed SiteId to siteID
+%   - removed Derived_Variables from the path when processing of a siteID is finished.
+%     Leaving it to linger around could mess up running of some other programs/sites
+%     during the current Matlab session (used to stay persistant until Matlab session is closed)
 % Feb 12, 2024 (Zoran)
 %   - Limitted running DerivedVariablesForGapFilling on Micromet sites
 %     only.
@@ -68,9 +73,9 @@ function fr_automated_cleaning(Years,Sites,stages,db_out,db_ini)
 % Sep 21, 2022 (Zoran)
 %   - change path creation to make it work compatible with MacOS:
 %     Changed:
-%       pth_out_second = fullfile(db_out,yy_str,SiteId,'clean\SecondStage','');
+%       pth_out_second = fullfile(db_out,yy_str,siteID,'clean\SecondStage','');
 %     to
-%       pth_out_second = fullfile(db_out,yy_str,SiteId,'clean','SecondStage','');
+%       pth_out_second = fullfile(db_out,yy_str,siteID,'clean','SecondStage','');
 % Aug 10, 2022 (Zoran)
 %   - Had to change my mind about preventing (error-ing)on the use of
 %     db_out option. Some of our backup programs might be using this
@@ -149,7 +154,7 @@ All_Sites     = {'BS'   'CR' 'FEN' 'HJP02' 'HJP75' 'JP'   'OY' 'PA'   'YF' 'LGR1
 arg_default('Sites',All_Sites)
 
 if ~iscellstr(Sites) %#ok<ISCLSTR>
-    % Assume it is a string with a single SiteId
+    % Assume it is a string with a single siteID
     Sites = cellstr(Sites);
 end
 
@@ -200,41 +205,41 @@ numOfYears = length(Years);
 numOfSites = length(Sites);
 
 for cntSites = 1:numOfSites
-    SiteId = upper(char(Sites(cntSites)));
+    siteID = upper(char(Sites(cntSites)));
     
     for cntYears = 1:numOfYears
         yy = Years(cntYears);
         yy_str = num2str(yy(1));
         try
-            fid = fopen(fullfile(db_pth,yy_str,SiteId,'automated_cleaning.log'),'a');
+            fid = fopen(fullfile(db_pth,yy_str,siteID,'automated_cleaning.log'),'a');
             if fid > -1
                 fclose(fid);
-                diary(fullfile(db_pth,yy_str,SiteId,'automated_cleaning.log'));
+                diary(fullfile(db_pth,yy_str,siteID,'automated_cleaning.log'));
             else
-                disp(['Write protected file: ' fullfile(db_pth,yy_str,SiteId,'automated_cleaning.log')]);
+                disp(['Write protected file: ' fullfile(db_pth,yy_str,siteID,'automated_cleaning.log')]);
             end
         catch ME
             disp(ME.message);
         end
         fprintf('==============  Start =========================================\n');
         fprintf('Date: %s\n',datetime);
-        fprintf('SiteId = %s\n',SiteId);
+        fprintf('siteID = %s\n',siteID);
         
         %------------------------------------------------------------------
         % Get output paths
         %------------------------------------------------------------------
-        pth_out_first  = fullfile(db_out,yy_str,SiteId,'');
-        pth_out_second = fullfile(db_out,yy_str,SiteId,'clean','SecondStage','');
-        pth_out_third  = fullfile(db_out,yy_str,SiteId,'clean','ThirdStage', '');
+        pth_out_first  = fullfile(db_out,yy_str,siteID,'');
+        pth_out_second = fullfile(db_out,yy_str,siteID,'clean','SecondStage','');
+        pth_out_third  = fullfile(db_out,yy_str,siteID,'clean','ThirdStage', '');
         
         %------------------------------------------------------------------
         % Do first stage cleaning and exporting
         %------------------------------------------------------------------
         if ~isempty(find(stages == 1)) %#ok<*EFIND>
             stage_str = 'First ';
-            disp(['============== ' stage_str ' stage cleaning ' SiteId ' ' yy_str ' ==============']);
-            db_dir_ini(yy(1),SiteId,db_out,1);
-            data_first = fr_cleaning_siteyear(yy(1),SiteId,1,db_ini);
+            disp(['============== ' stage_str ' stage cleaning ' siteID ' ' yy_str ' ==============']);
+            db_dir_ini(yy(1),siteID,db_out,1);
+            data_first = fr_cleaning_siteyear(yy(1),siteID,1,db_ini);
             ta_export(data_first,pth_out_first);
             fprintf('============== End of cleaning stage 1 =============\n');
         end
@@ -244,10 +249,10 @@ for cntSites = 1:numOfSites
         %------------------------------------------------------------------
         if ~isempty(find(stages == 2))
             stage_str = 'Second';
-            disp(['============== ' stage_str ' stage cleaning ' SiteId ' ' yy_str ' ==============']);
+            disp(['============== ' stage_str ' stage cleaning ' siteID ' ' yy_str ' ==============']);
             
-            db_dir_ini(yy(1),SiteId,db_out,2);
-            data_second = fr_cleaning_siteyear(yy(1),SiteId,2,db_ini);
+            db_dir_ini(yy(1),siteID,db_out,2);
+            data_second = fr_cleaning_siteyear(yy(1),siteID,2,db_ini);
             ta_export(data_second,pth_out_second);
             fprintf('============== End of cleaning stage 2 =============\n');
         end
@@ -257,9 +262,9 @@ for cntSites = 1:numOfSites
         %------------------------------------------------------------------
         if ~isempty(find(stages == 3))
             stage_str = 'Third ';
-            disp(['============== ' stage_str ' stage cleaning ' SiteId ' ' yy_str ' ==============']);
-            db_dir_ini(yy(1),SiteId,db_out,3);
-            data_third = fr_cleaning_siteyear(yy(1),SiteId,3,db_ini);
+            disp(['============== ' stage_str ' stage cleaning ' siteID ' ' yy_str ' ==============']);
+            db_dir_ini(yy(1),siteID,db_out,3);
+            data_third = fr_cleaning_siteyear(yy(1),siteID,3,db_ini);
             ta_export(data_third,pth_out_third);
             fprintf('============== End of cleaning stage 3 =============\n');
         end
@@ -268,9 +273,9 @@ for cntSites = 1:numOfSites
         % Do FCRN exporting
         %------------------------------------------------------------------
         if ~isempty(find(stages == 4))
-            disp(['============== ' SiteId ' - FCRN Export =================================']);
+            disp(['============== ' siteID ' - FCRN Export =================================']);
             data_fcrn = fcrn_trace_str(data_first,data_second,data_third);
-            fcrnexport(SiteId,data_fcrn);
+            fcrnexport(siteID,data_fcrn);
             fprintf('============== End of cleaning stage 4 =============\n');
         end
         
@@ -279,10 +284,10 @@ for cntSites = 1:numOfSites
         % Do a local FCRN export right up to current day
         %------------------------------------------------------------------
         if ~isempty(find(stages == 5))
-            disp(['============== ' SiteId ' - Local FCRN Export =================================']);
+            disp(['============== ' siteID ' - Local FCRN Export =================================']);
             data_fcrn_local = fcrn_trace_str(data_first,data_second,data_third);
             flag_local = 1;
-            fcrnexport(SiteId,data_fcrn_local,flag_local);
+            fcrnexport(siteID,data_fcrn_local,flag_local);
             fprintf('============== End of cleaning stage 5 =============\n');
         end
         
@@ -291,14 +296,14 @@ for cntSites = 1:numOfSites
         %------------------------------------------------------------------
         if dailymode | ~isempty(find(stages==6)) %#ok<*OR2> % July 10, 2007: added a stage 6 so we can produce web graphs explicitly by site
             try
-                if ismember(SiteId,{'HP09' 'HP11' 'MPB1' 'MPB2' 'MPB3'})
-                    opsite_web_analysis(yy(1),SiteId);
+                if ismember(siteID,{'HP09' 'HP11' 'MPB1' 'MPB2' 'MPB3'})
+                    opsite_web_analysis(yy(1),siteID);
                     autoGraph(data_first)
                 else
                     autoGraph(data_third)
                 end
             catch
-                disp(['Could not generate graphs for ' SiteId ' ' yy_str]);
+                disp(['Could not generate graphs for ' siteID ' ' yy_str]);
             end
         end
         
@@ -311,9 +316,9 @@ for cntSites = 1:numOfSites
         %------------------------------------------------------------------
         if ~isempty(find(stages == 7))
             stage_str = '7-th';
-            disp(['============== ' stage_str ' stage cleaning ' SiteId ' ' yy_str ' ==============']);
-            db_dir_ini(yy(1),SiteId,db_out,3);
-            runThirdStageCleaningREddyProc(yy(1),SiteId,'fast',2);  % use only 2 years for gap filling
+            disp(['============== ' stage_str ' stage cleaning ' siteID ' ' yy_str ' ==============']);
+            db_dir_ini(yy(1),siteID,db_out,3);
+            runThirdStageCleaningREddyProc(yy(1),siteID,'fast',2);  % use only 2 years for gap filling
             fprintf('============== End of cleaning stage 7 =============\n');
         end
         
@@ -323,15 +328,17 @@ for cntSites = 1:numOfSites
         %------------------------------------------------------------------
         if ~isempty(find(stages == 8))
             stage_str = '8-th';
-            disp(['============== ' stage_str ' stage. Exporting AmeriFlux csv file for: ' SiteId ' ' yy_str ' ==============']);
-            pathAF = fullfile(db_pth,num2str(yy(1)),SiteId,'Clean','Ameriflux');
-            saveDatabaseToAmeriFluxCSV(SiteId,yy(1),pathAF);
+            disp(['============== ' stage_str ' stage. Exporting AmeriFlux csv file for: ' siteID ' ' yy_str ' ==============']);
+            pathAF = fullfile(db_pth,num2str(yy(1)),siteID,'Clean','Ameriflux');
+            saveDatabaseToAmeriFluxCSV(siteID,yy(1),pathAF);
             fprintf('============== End of cleaning stage 8 =============\n'); 
         end          
         clear data_* ini_* pth_* mat_*
     end
-    
-    fprintf('============== End of cleaning Site: %s, year: %d ===========\n',SiteId,yy(1));
+    % Remove Derived_Variables path from the path
+    rmpath( biomet_path('Calculation_Procedures\TraceAnalysis_ini',siteID,'Derived_Variables'))
+
+    fprintf('============== End of cleaning Site: %s, year: %d ===========\n',siteID,yy(1));
     
     if ~isempty(hTimer)
         % restart the original diary file name

--- a/matlab/TRACEANALYSIS_FIRSTSTAGE/ta_get_index_traceList.m
+++ b/matlab/TRACEANALYSIS_FIRSTSTAGE/ta_get_index_traceList.m
@@ -35,16 +35,33 @@ structAllTraceNames = {list_of_traces.variableName};
 % Find if there are any tags (tag_*) in the list of dependents
 structAllTags = structTraceName(startsWith(structTraceName,'tag_'));
 
+% Add custom tags from siteID_CustomTags.m file if such file exists
+% under Derived_Variables
+%--- to be implemented -------
+siteID = list_of_traces(1).SiteID;
+fileName = [siteID '_CustomTags'];
+if exist(fileName,'file')
+    customTags = eval(fileName);
+    customTagFieldNames = fieldnames(customTags);
+else
+    customTagFieldNames = [];
+end
+
 % if tags exist, convert them to trace names and add them
 % to the list of dependants
 if ~isempty(structAllTags)
     indTaggedDependants = [];
     for cntTags = 1:length(structAllTags)
         cTag = char(structAllTags(cntTags));
+        indField = ismember(customTagFieldNames,cTag);
         % Deal with special tags (tag_ALL, tag_AllMet, tag_AllFlux)        
         if strcmpi(cTag,'tag_All')
             % tag_All affects all traces
             indTaggedDependants = 1:length(list_of_traces);
+        elseif indField ~= 0
+            % if cTag is memeber of customTags than add those trace names
+            structCustomTagTraces = split(customTags.(char(customTagFieldNames(indField))),',')';
+            structTraceName = [structTraceName structCustomTagTraces]; %#ok<AGROW>
         else
             % loop through all the traces and find all the ones that have this tag
             for cntTraces = 1:length(list_of_traces)

--- a/matlab/TRACEANALYSIS_FIRSTSTAGE/ta_get_index_traceList.m
+++ b/matlab/TRACEANALYSIS_FIRSTSTAGE/ta_get_index_traceList.m
@@ -14,7 +14,7 @@ function returnInd = ta_get_index_traceList(trc_names,list_of_traces)
 %   - fixed syntax errors
 %   - symplified the code
 %   - added handling of tags
-%   - implemented a meta tag: "Tag_All". More to follow.
+%   - implemented a meta tag: "tag_All". More to follow.
 
 
 returnInd = [];

--- a/matlab/TRACEANALYSIS_FIRSTSTAGE/ta_get_index_traceList.m
+++ b/matlab/TRACEANALYSIS_FIRSTSTAGE/ta_get_index_traceList.m
@@ -1,50 +1,80 @@
-function answer = ta_get_index_traceList(trc_names,list_of_traces)
-%This function returns the indices of the traces listed in 'trc_names' 
-%within the list of all traces present in the ini_file.
+function returnInd = ta_get_index_traceList(trc_names,list_of_traces)
+%   This function returns the indices of the traces listed in 'trc_names' 
+%   within the list of all traces present in the ini_file.
 %
-%Input:	'trc_names'			-a character array of trace variableNames
+%   Input:	'trc_names'			-a character array of trace variableNames
 %			'list_of_traces'	-contains list of all traces present in the ini_file.
-%Output:	'answer'				-contains indices of trc_names within list_of_traces.
+%   Output:	'returnInd'			-contains indices of trc_names within list_of_traces.
+%
+% Last modification:    Mar 22, 2024 
+
+% Revisions
+%
+% Mar 22, 2024 (Zoran)
+%   - fixed syntax errors
+%   - symplified the code
+%   - added handling of tags
+%   - implemented a meta tag: "Tag_All". More to follow.
 
 
-answer = [];
-if ~exist('trc_names') | ~exist('list_of_traces') | ...
-      isempty(trc_names) | isempty(list_of_traces)
+returnInd = [];
+if ~exist('trc_names','var') || ~exist('list_of_traces','var') || ...
+      isempty(trc_names) || isempty(list_of_traces)
    return
 end
-%First, remove all white space since it should not be present(variable names of traces
-%should only contain character and underscores):
-ind = find(trc_names ~=32 & trc_names ~=9);
-trc_names = trc_names(ind);
+% First, remove all white space since it should not be present(variable names of traces
+% should only contain character and underscores):
+trc_names = trc_names(trc_names ~=32 & trc_names ~=9);
 
-%First seperate the string between commas:
-ind = find(trc_names == ','); 
-temp = trc_names;
+% Split comma separated string trc_names into a structure:
+structTraceName = split(trc_names,',');
 
-%parse the string into a 'cell' data type:
-if ~isempty(ind)
-   temp = {trc_names(1:ind(1)-1)};
-   for j=1:length(ind)
-      if length(ind) >= j+1
-         temp = [temp {trc_names(ind(j)+1:ind(j+1)-1)}];
-      else
-         temp = [temp {trc_names(ind(j)+1:end)}];
-      end            
-   end
-end 
-%Get the indices of all traces:
-[val bi ci]=intersect(temp,{list_of_traces.variableName});
-% kai* 10 Nov, 2000
-% Before, this read
-%   answer =  ci';
-% The new MATLAB returns ci as a column. So it is reversed to a row if neccessary
-[n,m] = size(ci);
-if n<m
-   answer = ci;
-else 
-   answer =  ci';
+% Structure of all trace names
+structAllTraceNames = {list_of_traces.variableName};
+
+% Find if there are any tags (tag_*) in the list of dependents
+structAllTags = structTraceName(startsWith(structTraceName,'tag_'));
+
+% if tags exist, convert them to trace names and add them
+% to the list of dependants
+if ~isempty(structAllTags)
+    indTaggedDependants = [];
+    for cntTags = 1:length(structAllTags)
+        cTag = char(structAllTags(cntTags));
+        % Deal with special tags (tag_ALL, tag_AllMet, tag_AllFlux)        
+        if strcmpi(cTag,'tag_All')
+            % tag_All affects all traces
+            indTaggedDependants = 1:length(list_of_traces);
+        else
+            % loop through all the traces and find all the ones that have this tag
+            for cntTraces = 1:length(list_of_traces)
+                if isfield(list_of_traces(cntTraces).ini,'tag') && contains(list_of_traces(cntTraces).ini.tag,cTag)
+                    %fprintf('%d found tag\n',cntTraces);
+                    indTaggedDependants = [indTaggedDependants cntTraces];   %#ok<AGROW>
+                end
+            end
+        end
+    end
+
+    % remove tags from structTraceName 
+    structTraceName = structTraceName(~startsWith(structTraceName,'tag_'));
+    % and replace them with unique trace names
+    nDep = length(structTraceName);
+    for cnt = 1:length(indTaggedDependants)
+        structTraceName{cnt+nDep} = char(structAllTraceNames(indTaggedDependants(cnt)));
+    end
+    structTraceName = unique(structTraceName);
+
 end
-% end kai*
+
+
+
+% Get the indices of all traces:
+[~, ~, returnInd]=intersect(structTraceName,structAllTraceNames);
+
+% make sure that returnInd is a row vector
+returnInd = returnInd(:)';
+
 
 
 

--- a/matlab/TRACEANALYSIS_FIRSTSTAGE/ta_get_index_traceList.m
+++ b/matlab/TRACEANALYSIS_FIRSTSTAGE/ta_get_index_traceList.m
@@ -60,7 +60,7 @@ if ~isempty(structAllTags)
             indTaggedDependants = 1:length(list_of_traces);
         elseif indField ~= 0
             % if cTag is memeber of customTags than add those trace names
-            structCustomTagTraces = split(customTags.(char(customTagFieldNames(indField))),',')';
+            structCustomTagTraces = strtrim(split(customTags.(char(customTagFieldNames(indField))),','))';
             structTraceName = [structTraceName structCustomTagTraces]; %#ok<AGROW>
         else
             % loop through all the traces and find all the ones that have this tag

--- a/matlab/TRACEANALYSIS_FIRSTSTAGE/ta_get_index_traceList.m
+++ b/matlab/TRACEANALYSIS_FIRSTSTAGE/ta_get_index_traceList.m
@@ -27,13 +27,10 @@ end
 trc_names = trc_names(trc_names ~=32 & trc_names ~=9);
 
 % Split comma separated string trc_names into a structure:
-structTraceName = split(trc_names,',');
+structNamesOfDependants = split(trc_names,',');
 
 % Structure of all trace names
-structAllTraceNames = {list_of_traces.variableName};
-
-% Find if there are any tags (tag_*) in the list of dependents
-structAllTags = structTraceName(startsWith(structTraceName,'tag_'));
+structAllVariableNames = {list_of_traces.variableName};
 
 % Add custom tags from siteID_CustomTags.m file if such file exists
 % under Derived_Variables
@@ -41,57 +38,78 @@ structAllTags = structTraceName(startsWith(structTraceName,'tag_'));
 siteID = list_of_traces(1).SiteID;
 fileName = [siteID '_CustomTags'];
 if exist(fileName,'file')
-    customTags = eval(fileName);
-    customTagFieldNames = fieldnames(customTags);
+    customTags = eval(fileName);   
 else
-    customTagFieldNames = [];
+    customTags = [];
 end
 
-% if tags exist, convert them to trace names and add them
-% to the list of dependants
-if ~isempty(structAllTags)
-    indTaggedDependants = [];
-    for cntTags = 1:length(structAllTags)
-        cTag = char(structAllTags(cntTags));
-        indField = ismember(customTagFieldNames,cTag);
-        % Deal with special tags (tag_ALL, tag_AllMet, tag_AllFlux)        
-        if strcmpi(cTag,'tag_All')
-            % tag_All affects all traces
-            indTaggedDependants = 1:length(list_of_traces);
-        elseif indField ~= 0
-            % if cTag is memeber of customTags than add those trace names
-            structCustomTagTraces = strtrim(split(customTags.(char(customTagFieldNames(indField))),','))';
-            structTraceName = [structTraceName structCustomTagTraces]; %#ok<AGROW>
-        else
-            % loop through all the traces and find all the ones that have this tag
-            for cntTraces = 1:length(list_of_traces)
-                if isfield(list_of_traces(cntTraces).ini,'tag') && contains(list_of_traces(cntTraces).ini.tag,cTag)
-                    %fprintf('%d found tag\n',cntTraces);
-                    indTaggedDependants = [indTaggedDependants cntTraces];   %#ok<AGROW>
-                end
-            end
-        end
-    end
-
-    % remove tags from structTraceName 
-    structTraceName = structTraceName(~startsWith(structTraceName,'tag_'));
-    % and replace them with unique trace names
-    nDep = length(structTraceName);
-    for cnt = 1:length(indTaggedDependants)
-        structTraceName{cnt+nDep} = char(structAllTraceNames(indTaggedDependants(cnt)));
-    end
-    structTraceName = unique(structTraceName);
-
-end
-
-
+structNamesOfDependants = convert_tags_to_Traces(list_of_traces,structNamesOfDependants,customTags);
 
 % Get the indices of all traces:
-[~, ~, returnInd]=intersect(structTraceName,structAllTraceNames);
+[~, ~, returnInd]=intersect(structNamesOfDependants,structAllVariableNames);
 
 % make sure that returnInd is a row vector
 returnInd = returnInd(:)';
 
 
+function structNamesOfDependants = convert_tags_to_Traces(list_of_traces,structNamesOfDependants,customTags)
+    % It converts 
+    % Recursive search through all Tags to convert them to trace names 
+    
+    % Extract field names
+    if ~isempty(customTags)
+        customTagFieldNames = fieldnames(customTags);
+    else
+        customTagFieldNames = [];
+    end
 
+    % Structure of all trace names
+    structAllVariableNames = {list_of_traces.variableName};
 
+    % Find if there are any tags (tag_*) in the list of dependents
+    indAllTagsInDependents = startsWith(structNamesOfDependants,'tag_');
+    % move them to structAllTags
+    structAllTags = structNamesOfDependants(indAllTagsInDependents);
+    % and remove them from structNamesOfDependants
+    structNamesOfDependants = structNamesOfDependants(~indAllTagsInDependents);
+
+    % if tags exist, convert them to trace names and add them
+    % to the list of dependants
+    if ~isempty(structAllTags)
+        indTaggedDependants = [];
+        for cntTags = 1:length(structAllTags)
+            cTag = char(structAllTags(cntTags));
+            indField = find(ismember(customTagFieldNames,cTag));
+            if ~isempty(indField)
+                indField = indField(1);   % in case user made a mistake and there a same tag appears twice grab only the first one
+            end
+            % Deal with special tags (tag_ALL, tag_AllMet, tag_AllFlux)        
+            if strcmpi(cTag,'tag_All')
+                % tag_All affects all traces
+                indTaggedDependants = 1:length(list_of_traces);
+            elseif indField ~= 0
+                % if cTag is memeber of customTags than add those trace names
+                structCustomTagTraces = strtrim(split(customTags.(char(customTagFieldNames(indField))),','))';
+                structNamesOfDependants = [structNamesOfDependants structCustomTagTraces]; %#ok<AGROW>
+                % recursive call to check if there are more tag_ fields
+                structNamesOfDependants = convert_tags_to_Traces(list_of_traces,structNamesOfDependants,customTags);
+            else
+                % loop through all the traces and find all the ones that have this tag
+                for cntTraces = 1:length(list_of_traces)
+                    if isfield(list_of_traces(cntTraces).ini,'tag') && contains(list_of_traces(cntTraces).ini.tag,cTag)
+                        %fprintf('%d found tag\n',cntTraces);
+                        indTaggedDependants = [indTaggedDependants cntTraces];   %#ok<AGROW>
+                    end
+                end
+            end
+        end
+    
+        % remove tags from structTraceName 
+        structNamesOfDependants = structNamesOfDependants(~startsWith(structNamesOfDependants,'tag_'));
+        % and replace them with unique trace names
+        nDep = length(structNamesOfDependants);
+        for cnt = 1:length(indTaggedDependants)
+            structNamesOfDependants{cnt+nDep} = char(structAllVariableNames(indTaggedDependants(cnt)));
+        end
+        structNamesOfDependants = unique(structNamesOfDependants);
+    end


### PR DESCRIPTION
Added ability to use tags for data cleaning. Tags are meant to improve readability of the FirstStage.ini files. For each site one could create a Matlab file siteID_CustomTags.m (it goes under DerivedVariables folder) and create a structure where each field represents a tag and each tag translates into dependent trace-names. The tags can be nested (one tag can consist of one or more tags mixed with or without regular trace-names.

Each tag field starts with "tag_".

The "Dependent" field still works as usual (tags don't have to be used). If there is no siteID_CustomTags.m everything works as before.

Here is an example:
```matlab
function tagsOut = Example_CustomTags
% Define custom tags. Used to clean up and better organize FistStage.ini files
% Any tag under tagsOut can appear inside of the "Dependent" field within [Trace]-[End]. 
% Example:
%   This line will cause all CO2 and H2O based trace points to be removed when
%   the pump is dead (flow<1 or such).
%
%		Dependent = 'tag_LI7200_pump_dead'
%
% 


% Tag for low CO2 signal strength
tagsOut.tag_CO2_Low_Signal = [  'tag_AllCO2,' ...	
							 ];

% if CO2 signal is bad tag all CO2 dependent variables 
tagsOut.tag_AllCO2 = [  'CO2,' ...
                        'CO2_MIXING_RATIO,'...
                        'tag_SomeRand,' ...
                        'co2_var,'...
                        'un_co2_flux,'...
                        'FC,'...
                        'w_co2_cov,'...
                        'SC'...
                        ];

% if H2O signal is bad tag all H2O dependent variables 
tagsOut.tag_AllH2O = [...
		                'SH,'...
	                    'H2O,'...
	                    'H2O_MIXING_RATIO,'...		    
	                    'h2o_flux,'...
	                    'LE,'...
	                    'ET,'...
	                    'un_co2_flux,'...
	                    'un_h2o_flux,'...
	                    'un_LE  ,'...
	                    'h2o_var,'...
	                    'w_h2o_cov,'...
	                    'air_p_mean,'...                        
	                    'SLE'...
                        ];

% if the pump is dead remove all CO2 and H2O dependent traces.						
tagsOut.tag_LI7200_pump_dead = [ ...
						'tag_AllCO2,' ...	
						'tag_AllH2O,' ...									
							    ];
``` 
I also added an option to use "Tag = " fields within [Trace]-[End] which can also help with the trace grouping (FC could be a member of tag_EC, tag_LI7200. From what I can figure out, this can help with readability but it doesn't reduce the ini file size the way that siteID_CustomeTags.m does. 
```matlab
[Trace]
	variableName = 'CO2'
	title = 'CO2 in mole fraction of wet air'
	originalVariable = 'CO2 in mole fraction of wet air'
	inputFileName = {'co2_mole_fraction'}
	inputFileName_dates = [datenum(2021,1,1) datenum(2999,1,1)] 
	measurementType = 'flux'
	units = '\mu mol / mol wet air'
	instrument = 'LI-7200'
	instrumentSN = '72H-1029'
	calibrationDates = ''
	comments = ''
	tag = 'tag_CO2,tag_other_junk'
	minMax = [300,800]
	zeroPt = [-9999]
	
	plotTopLeft     = ''
	plotTopRight    = ''
	plotBottomRight = ''
[End]
``` 
